### PR TITLE
CHEF-30592 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -143,3 +143,7 @@ These samples are intended to serve as a reference, allowing you to adapt and cu
 `NM Attribute Names`: The `nm_attr_name` is user-defined and can be any name of your choosing. The corresponding value will be stored under this name in your node management attributes.
 
 `PUT vs PATCH`: Use `PUT` when you want to completely overwrite the existing data at the endpoint. Use `PATCH` when you want to update only specific fields without affecting the others.
+
+# Copyright
+
+See [COPYRIGHT.md](./COPYRIGHT.md).


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2024-2025 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
